### PR TITLE
新增Jackie's Blog友情链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ npm run docs:build
 - <image src="https://forum.smart-teach.cn/assets/favicon-v4ksoaxf.png" height="18"/> [**SmartTeachCN**](https://forum.smart-teach.cn/) - 智教联盟致力于为教学辅助类应用提供全方面扶持与帮助。
 - <image src="https://avatars.githubusercontent.com/u/184760810" height="18"/> **[Awesome-Iwb](https://github.com/awesome-iwb/awesome-iwb)** - ✨ 全网最全的 教学辅助软件/一体机软件 推荐清单
 - <image src="https://nav.jursin.top/acs.png" height="18"/> [**Awesome-Class-Softwares**](https://github.com/Jursin/Awesome-Class-Softwares) - 🌟 适用于班级一体机的优质软件合集
+- <image src="https://avatars.githubusercontent.com/u/211526759" height="18"/> [**Jackie's Blog**](https://jackie.openenet.cn/) - 这里是 Jackie 的个人博客，一名热爱技术的中国学生。专注分享区块链、智能合约、以太坊、CI/CD、开源项目以及 IT 基础设施的深度解析与实践笔记。

--- a/docs/.vitepress/theme/untils/FooterData.ts
+++ b/docs/.vitepress/theme/untils/FooterData.ts
@@ -19,6 +19,7 @@ export const footerData: FooterInfo = {
         { text: "智教联盟论坛", url: "https://forum.smart-teach.cn/", icon: '<img src="https://forum.smart-teach.cn/assets/favicon-v4ksoaxf.png" alt="stcn" width="14" height="14">' },
         { text: "Awesome-Iwb", url: "https://github.com/awesome-iwb/awesome-iwb",icon: '<img src="/images/aiwb.png" alt="awesome-iwb" width="14" height="14">' },
         { text: "Awesome-Class-Softwares", url: "https://github.com/Jursin/Awesome-Class-Softwares", icon: '<img src="https://nav.jursin.top/acs.png" alt="awesome-class-softwares" width="14" height="14">' },
+        { text: "Jackie's Blog", url: "https://jackie.openenet.cn/", icon: '<img src="https://avatars.githubusercontent.com/u/211526759" alt="jackie-blog" width="14" height="14">' },
       ]
     },
   ]

--- a/docs/.vitepress/theme/untils/friendLinks.ts
+++ b/docs/.vitepress/theme/untils/friendLinks.ts
@@ -24,4 +24,10 @@ export const friendLinks: FriendLink[] = [
     description: "适用于班级一体机的优质软件合集🌟",
     url: "https://github.com/Jursin/Awesome-Class-Softwares",
   },
+  {
+    icon: "https://avatars.githubusercontent.com/u/211526759",
+    title: "Jackie's Blog",
+    description: "这里是 Jackie 的个人博客，一名热爱技术的中国学生。专注分享区块链、智能合约、以太坊、CI/CD、开源项目以及 IT 基础设施的深度解析与实践笔记。",
+    url: "https://jackie.openenet.cn/",
+  },
 ];


### PR DESCRIPTION
新增友链：Jackie's Blog
站点名称：Jackie's Blog
站点地址：https://jackie.openenet.cn/
站点简介：这里是 Jackie 的个人博客，一名热爱技术的中国学生。专注分享区块链、智能合约、以太坊、CI/CD、开源项目以及 IT 基础设施的深度解析与实践笔记。

注：本人成都外国语学校初中生，博客初建(ψ(._. )>，还请关照。（后续会出关于电教的博文）

如果站长同意新增友链，请移步https://github.com/PyXMR2025/blog/pull/38并批注（Approved）这个PR。

感谢！